### PR TITLE
Parse XML files from the CAPP database

### DIFF
--- a/parsing_CAPP/capp.xsd
+++ b/parsing_CAPP/capp.xsd
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="TEXTE_JURI_JUDI" type="TEXTE_JURI_JUDI"/>
+
+    <xs:complexType name="TEXTE_JURI_JUDI">
+        <xs:sequence>
+            <xs:element name="META" type="META"/>
+            <xs:element name="TEXTE" type="TEXTE"/>
+            <xs:element name="LIENS" type="LIENS"/>
+        </xs:sequence>
+    </xs:complexType>
+ 
+    <xs:complexType name="META">
+        <xs:sequence>
+            <xs:element name="META_COMMUN" type="META_COMMUN"/>
+            <xs:element name="META_SPEC" type="META_SPEC"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="META_COMMUN">
+        <xs:sequence>
+            <xs:element name="ID" type="xs:string"/>
+            <xs:element name="ANCIEN_ID" type="xs:string"/>
+            <xs:element name="ORIGINE" type="xs:string"/>
+            <xs:element name="URL" type="xs:string"/>
+            <xs:element name="NATURE" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="META_SPEC">
+        <xs:sequence>
+            <xs:element name="META_JURI" type="META_JURI"/>
+            <xs:element name="META_JURI_JUDI" type="META_JURI_JUDI"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="META_JURI">
+        <xs:sequence>
+            <xs:element name="TITRE" type="xs:string"/>
+            <xs:element name="DATE_DEC" type="xs:date"/>
+            <xs:element name="JURIDICTION" type="xs:string"/>
+            <xs:element name="NUMERO" type="xs:string"/>
+            <xs:element name="SOLUTION" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="META_JURI_JUDI">
+        <xs:sequence>
+            <xs:element name="NUMEROS_AFFAIRES">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="NUMERO_AFFAIRE" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="PUBLI_BULL" >
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attribute name="publie" type="xs:string"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="FORMATION" type="xs:string"/>
+            <xs:element name="FORM_DEC_ATT" type="xs:string"/>
+            <xs:element name="DATE_DEC_ATT" type="xs:string"/>
+            <xs:element name="SIEGE_APPEL" type="xs:string"/>
+            <xs:element name="JURI_PREM" type="xs:string"/>
+            <xs:element name="LIEU_PREM" type="xs:string"/>
+            <xs:element name="DEMANDEUR" type="xs:string"/>
+            <xs:element name="DEFENDEUR" type="xs:string"/>
+            <xs:element name="PRESIDENT" type="xs:string"/>
+            <xs:element name="AVOCAT_GL" type="xs:string"/>
+            <xs:element name="AVOCATS" type="xs:string"/>
+            <xs:element name="RAPPORTEUR" type="xs:string"/>
+            <xs:element name="ECLI" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TEXTE">
+        <xs:sequence>
+            <xs:element name="BLOC_TEXTUEL" type="BLOC_TEXTUEL"/>
+            <xs:element name="SOMMAIRE" type="SOMMAIRE"/>
+            <xs:element name="CITATION_JP" type="CITATION_JP"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="BLOC_TEXTUEL">
+        <xs:sequence>
+            <xs:element name="CONTENU">
+                <xs:complexType mixed="true">
+                    <xs:sequence>
+                        <xs:any processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                    <xs:anyAttribute processContents="skip"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="SOMMAIRE">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="SCT" type="SCT"/>
+                <xs:element name="ANA" type="ANA"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="SCT">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="ID" type="xs:string"/>
+                <xs:attribute name="TYPE" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="ANA">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="ID" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="CITATION_JP">
+        <xs:sequence>
+            <xs:element name="CONTENU" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="LIENS">
+        <xs:sequence>
+            <xs:element name="LIEN" type="LIEN" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="LIEN">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="cidtexte" type="xs:string"/>
+                <xs:attribute name="datesignatexte" type="xs:string"/>
+                <xs:attribute name="id" type="xs:string"/>
+                <xs:attribute name="naturetexte" type="xs:string"/>
+                <xs:attribute name="nortexte" type="xs:string"/>
+                <xs:attribute name="num" type="xs:string"/>
+                <xs:attribute name="numtexte" type="xs:string"/>
+                <xs:attribute name="sens" type="xs:string"/>
+                <xs:attribute name="typelien" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/parsing_CAPP/explore_CAPP.ipynb
+++ b/parsing_CAPP/explore_CAPP.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pickle\n",
+    "\n",
+    "from collections import defaultdict, Counter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('../data/CAPP_obj.pickle', 'rb') as f:\n",
+    "    python_trees = pickle.load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "63340"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(python_trees)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Merge all docs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "values_by_tag = defaultdict(list)\n",
+    "for ident, doc in python_trees.items():\n",
+    "    for k, v in doc.items():\n",
+    "        if k != 'BLOC_TEXTUEL':\n",
+    "            values_by_tag[k].append(v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_stats(tag):\n",
+    "    counter = Counter(values_by_tag[tag])\n",
+    "    print(counter.most_common(100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "key_set = set(values_by_tag.keys())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(None, 63340)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_stats('DEFENDEUR')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'CITATION_JP',\n",
+       " 'DATE_DEC',\n",
+       " 'DATE_DEC_ATT',\n",
+       " 'FORMATION',\n",
+       " 'FORM_DEC_ATT',\n",
+       " 'ID',\n",
+       " 'JURIDICTION',\n",
+       " 'LIENS',\n",
+       " 'NATURE',\n",
+       " 'NUMERO',\n",
+       " 'NUMEROS_AFFAIRES',\n",
+       " 'ORIGINE',\n",
+       " 'PRESIDENT',\n",
+       " 'PUBLI_BULL_publie',\n",
+       " 'PUBLI_BULL_text',\n",
+       " 'RAPPORTEUR',\n",
+       " 'SIEGE_APPEL',\n",
+       " 'SOLUTION',\n",
+       " 'SOMMAIRE',\n",
+       " 'TITRE',\n",
+       " 'URL'}"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "not_interesting = {'ANCIEN_ID', 'AVOCATS', 'AVOCAT_GL', 'DEFENDEUR', 'DEMANDEUR', 'ECLI',\n",
+    "                   'JURI_PREM', 'LIEU_PREM', 'ORIGINE', 'PUBLI_BULL_publie', 'RAPPORTEUR'}\n",
+    "interesting_keys = key_set - not_interesting\n",
+    "interesting_keys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(None, 63340)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print_stats('RAPPORTEUR')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/parsing_CAPP/parse_CAPP.ipynb
+++ b/parsing_CAPP/parse_CAPP.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from lxml import etree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_dir = '../data/CAPP/CAPP_flat'\n",
+    "filenames = os.listdir(input_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "with open('capp.xsd', 'r') as f:\n",
+    "    xmlschema_doc = etree.parse(f)\n",
+    "    xmlschema = etree.XMLSchema(xmlschema_doc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parse CAPP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def parse_document(filename):\n",
+    "    \n",
+    "    input_path = os.path.join(input_dir, filename)\n",
+    "    with open(input_path, 'r') as f:\n",
+    "        tree = etree.parse(f)\n",
+    "    \n",
+    "    if not xmlschema.validate(tree):\n",
+    "        print(etree.tostring(tree, pretty_print=True, encoding='unicode'))\n",
+    "        raise ValueError(xmlschema.error_log.filter_from_errors())\n",
+    "    \n",
+    "    return tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "1000\n",
+      "2000\n",
+      "3000\n",
+      "4000\n",
+      "5000\n",
+      "6000\n",
+      "7000\n",
+      "8000\n",
+      "9000\n",
+      "10000\n",
+      "11000\n",
+      "12000\n",
+      "13000\n",
+      "14000\n",
+      "15000\n",
+      "16000\n",
+      "17000\n",
+      "18000\n",
+      "19000\n",
+      "20000\n",
+      "21000\n",
+      "22000\n",
+      "23000\n",
+      "24000\n",
+      "25000\n",
+      "26000\n",
+      "27000\n",
+      "28000\n",
+      "29000\n",
+      "30000\n",
+      "31000\n",
+      "32000\n",
+      "33000\n",
+      "34000\n",
+      "35000\n",
+      "36000\n",
+      "37000\n",
+      "38000\n",
+      "39000\n",
+      "40000\n",
+      "41000\n",
+      "42000\n",
+      "43000\n",
+      "44000\n",
+      "45000\n",
+      "46000\n",
+      "47000\n",
+      "48000\n",
+      "49000\n",
+      "50000\n",
+      "51000\n",
+      "52000\n",
+      "53000\n",
+      "54000\n",
+      "55000\n",
+      "56000\n",
+      "57000\n",
+      "58000\n",
+      "59000\n",
+      "60000\n",
+      "61000\n",
+      "62000\n",
+      "63000\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i, filename in enumerate(filenames):\n",
+    "    parse_document(filename)\n",
+    "    if i % 1000 == 0:\n",
+    "        print(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/parsing_CAPP/parse_CAPP.ipynb
+++ b/parsing_CAPP/parse_CAPP.ipynb
@@ -397,7 +397,7 @@
    "source": [
     "# to load :\n",
     "with open('../data/CAPP_obj.pickle', 'rb') as f:\n",
-    "    python_trees = pickle.dump(f)"
+    "    python_trees = pickle.load(f)"
    ]
   }
  ],

--- a/parsing_CAPP/parse_CAPP.ipynb
+++ b/parsing_CAPP/parse_CAPP.ipynb
@@ -2,20 +2,21 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
     "import os\n",
+    "import pickle\n",
     "\n",
     "from lxml import etree"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -52,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -73,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {
     "scrolled": true
    },
@@ -150,10 +151,240 @@
     }
    ],
    "source": [
+    "trees = {}\n",
     "for i, filename in enumerate(filenames):\n",
-    "    parse_document(filename)\n",
+    "    ident, _ = os.path.splitext(filename\n",
+    "                               )\n",
+    "    tree = parse_document(filename)\n",
+    "    trees[ident] = tree\n",
+    "    \n",
     "    if i % 1000 == 0:\n",
     "        print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parse to python objects\n",
+    "NB : lxml objects cannot be pickled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "leaf_tags = ['ID', 'ANCIEN_ID', 'ORIGINE', 'URL', 'NATURE', 'TITRE', 'DATE_DEC', \n",
+    "             'JURIDICTION', 'NUMERO', 'SOLUTION', 'FORMATION', 'FORM_DEC_ATT',\n",
+    "             'DATE_DEC_ATT', 'SIEGE_APPEL', 'JURI_PREM', 'LIEU_PREM', 'DEMANDEUR',\n",
+    "             'DEFENDEUR', 'PRESIDENT', 'AVOCAT_GL', 'AVOCATS', 'RAPPORTEUR', 'ECLI'\n",
+    "            ]\n",
+    "\n",
+    "special_tags = ['NUMEROS_AFFAIRES', 'PUBLI_BULL', 'BLOC_TEXTUEL', 'SOMMAIRE',\n",
+    "                'CITATION_JP', 'LIENS']\n",
+    "\n",
+    "def objectify_NUMEROS_AFFAIRES(node):\n",
+    "    numeros_affaires = []\n",
+    "    for child in node:\n",
+    "        child_text = child.text\n",
+    "        numeros_affaires.append(child_text)\n",
+    "        \n",
+    "    return {'NUMEROS_AFFAIRES': numeros_affaires}\n",
+    "\n",
+    "def objectify_PUBLI_BULL(node):\n",
+    "    publie = node.attrib['publie']\n",
+    "\n",
+    "    text = node.text\n",
+    "    if text:\n",
+    "        text = text.strip()\n",
+    "\n",
+    "    return {\n",
+    "        'PUBLI_BULL_publie': publie,\n",
+    "        'PUBLI_BULL_text': text,\n",
+    "    }\n",
+    "\n",
+    "def objectify_BLOC_TEXTUEL(node):\n",
+    "    assert len(node) == 1\n",
+    "    \n",
+    "    contenu = etree.tostring(node[0], encoding='unicode')\n",
+    "\n",
+    "    return {'BLOC_TEXTUEL': contenu}\n",
+    "\n",
+    "def objectify_SOMMAIRE(node):\n",
+    "    sommaire = []\n",
+    "    for child in node:\n",
+    "        if child.tag == 'SCT':\n",
+    "            sommaire.append({\n",
+    "                'child_type': 'SCT',\n",
+    "                'ID': child.attrib['ID'],\n",
+    "                'TYPE': child.attrib['TYPE'],\n",
+    "                'text': child.text,\n",
+    "            })\n",
+    "        elif child.tag == 'ANA':\n",
+    "            sommaire.append({\n",
+    "                'child_type': 'ANA',\n",
+    "                'ID': child.attrib['ID'],\n",
+    "                'text': child.text,\n",
+    "            })\n",
+    "    return {'SOMMAIRE': sommaire}\n",
+    "\n",
+    "def objectify_CITATION_JP(node):\n",
+    "    if len(node) == 0:\n",
+    "        return {}\n",
+    "    \n",
+    "    contenu = etree.tostring(node[0], encoding='utf-8')\n",
+    "\n",
+    "    return {'CITATION_JP': contenu}\n",
+    "\n",
+    "def objectify_LIENS(node):\n",
+    "    liens = []\n",
+    "    for child in node:\n",
+    "        lien = dict(node.attrib)\n",
+    "        lien['text'] = node.text\n",
+    "        liens.append(lien)\n",
+    "    return {'LIENS': liens}\n",
+    "\n",
+    "    \n",
+    "def objectify(node):\n",
+    "    tag = node.tag\n",
+    "    attrib = dict(node.attrib)\n",
+    "    text = node.text\n",
+    "    if text:\n",
+    "        text = text.strip()\n",
+    "    \n",
+    "    if tag in leaf_tags:\n",
+    "        assert not attrib\n",
+    "        return {tag: text}\n",
+    "    elif tag in special_tags:\n",
+    "        if tag == 'NUMEROS_AFFAIRES':\n",
+    "            return objectify_NUMEROS_AFFAIRES(node)\n",
+    "        elif tag == 'PUBLI_BULL':\n",
+    "            return objectify_PUBLI_BULL(node)\n",
+    "        elif tag == 'BLOC_TEXTUEL':\n",
+    "            return objectify_BLOC_TEXTUEL(node)\n",
+    "        elif tag == 'SOMMAIRE':\n",
+    "            return objectify_SOMMAIRE(node)\n",
+    "        elif tag == 'CITATION_JP':\n",
+    "            return objectify_CITATION_JP(node)\n",
+    "        elif tag == 'LIENS':\n",
+    "            return objectify_LIENS(node)\n",
+    "        raise ValueError()\n",
+    "    else:\n",
+    "\n",
+    "        content = {}\n",
+    "        for child in node:\n",
+    "            child_content = objectify(child)\n",
+    "            for k, v in child_content.items():\n",
+    "                assert k not in content\n",
+    "                content[k] = v\n",
+    "\n",
+    "        return content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1000\n",
+      "2000\n",
+      "3000\n",
+      "4000\n",
+      "5000\n",
+      "6000\n",
+      "7000\n",
+      "8000\n",
+      "9000\n",
+      "10000\n",
+      "11000\n",
+      "12000\n",
+      "13000\n",
+      "14000\n",
+      "15000\n",
+      "16000\n",
+      "17000\n",
+      "18000\n",
+      "19000\n",
+      "20000\n",
+      "21000\n",
+      "22000\n",
+      "23000\n",
+      "24000\n",
+      "25000\n",
+      "26000\n",
+      "27000\n",
+      "28000\n",
+      "29000\n",
+      "30000\n",
+      "31000\n",
+      "32000\n",
+      "33000\n",
+      "34000\n",
+      "35000\n",
+      "36000\n",
+      "37000\n",
+      "38000\n",
+      "39000\n",
+      "40000\n",
+      "41000\n",
+      "42000\n",
+      "43000\n",
+      "44000\n",
+      "45000\n",
+      "46000\n",
+      "47000\n",
+      "48000\n",
+      "49000\n",
+      "50000\n",
+      "51000\n",
+      "52000\n",
+      "53000\n",
+      "54000\n",
+      "55000\n",
+      "56000\n",
+      "57000\n",
+      "58000\n",
+      "59000\n",
+      "60000\n",
+      "61000\n",
+      "62000\n",
+      "63000\n"
+     ]
+    }
+   ],
+   "source": [
+    "python_trees = {}\n",
+    "i = 0\n",
+    "for ident, tree in trees.items():\n",
+    "    root = tree.getroot()\n",
+    "    python_tree = objectify(root)\n",
+    "    python_trees[ident] = python_tree\n",
+    "    \n",
+    "    i += 1\n",
+    "    if i % 1000 == 0:\n",
+    "        print(i)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "with open('../data/CAPP_obj.pickle', 'wb') as f:\n",
+    "    pickle.dump(python_trees, f)"
    ]
   },
   {
@@ -163,7 +394,11 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "# to load :\n",
+    "with open('../data/CAPP_obj.pickle', 'rb') as f:\n",
+    "    python_trees = pickle.dump(f)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Prend en entrée un dossier qui contient les XML de la base CAPP (dans la hierarchie de fichiers).

Parse et valide les fichiers avec le XML schema capp.xsd. A la fin, les arrêts sont sérialisés sous forme de dictionnaires python de faible profondeur (des str et quelques listes).

TODO : 
* [ ] même si la base est de taille modérée, je pense qu'il est préférable d'utiliser une base SQL. Je vais donc coder la mise en base des informations qui seront utiles par la suite.
* [ ] sélectionner les jurisprudence des prud'hommes
* [ ] et en particulier celles qui concernent un licenciement
* [ ] parse le HTML pour arriver à une liste de paragraphes